### PR TITLE
Add actual member to machine output

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,11 @@ TODO...? Some plugins based solution?
 
 ## TODO
 
-* TESTS
+* Tests
+  - config
 * Bootstrapping
-* Reload config on the fly and re-initialize
+* Reload config on the fly and re-initialize?? Or just restart the binary? Might actually be cleaner
+  and easier.
+* Start webservice before doing checkouts?
 * authentication for destructive action
 * TLS

--- a/cmd/gitopperctl/main.go
+++ b/cmd/gitopperctl/main.go
@@ -72,9 +72,9 @@ func main() {
 							if err := json.Unmarshal(body, &lm); err != nil {
 								return err
 							}
-							tbl := table.New("#", "MACHINE")
-							for i, m := range lm.Machines {
-								tbl.AddRow(i, m)
+							tbl := table.New("#", "MACHINE", "ACTUAL")
+							for i, m := range lm.ListMachines {
+								tbl.AddRow(i, m.Machine, m.Actual)
 							}
 							tbl.Print()
 							return nil

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -3,7 +3,12 @@ package proto
 
 type (
 	ListMachines struct {
-		Machines []string `json:"machines"`
+		ListMachines []ListMachine `json:"machines"`
+	}
+
+	ListMachine struct {
+		Machine string `json:"machine"` // Machine as set in config file.
+		Actual  string `json:"actual"`  // Actual machine responding (i.e. -h flag might be used)
 	}
 
 	ListServices struct {

--- a/router.go
+++ b/router.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -43,10 +44,14 @@ func newRouter(c Config) *mux.Router {
 
 func ListMachines(c Config, w http.ResponseWriter, r *http.Request) {
 	lm := proto.ListMachines{
-		Machines: make([]string, len(c.Services)),
+		ListMachines: make([]proto.ListMachine, len(c.Services)),
 	}
+	hostname, _ := os.Hostname()
 	for i, service := range c.Services {
-		lm.Machines[i] = service.Machine
+		lm.ListMachines[i] = proto.ListMachine{
+			Machine: service.Machine,
+			Actual:  hostname,
+		}
 	}
 	data, err := json.Marshal(lm)
 	if err != nil {


### PR DESCRIPTION
As machine can have multiple names (-h flag) it's probably handy to see
the real machine name in the output when queried by gitopperctl.

Some tweaks to the README.

Signed-off-by: Miek Gieben <miek@miek.nl>
