### PR TITLE
Restart services when new bind mounts are made

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,5 +131,6 @@ TODO...? Some plugins based solution?
 ## TODO
 
 * Bootstrapping
+ - need this binary on the machine -- can't help with that, and a git repo that get's pulled.
 * Authentication for destructive action
 * TLS (certmagic?)

--- a/gitcmd/git_test.go
+++ b/gitcmd/git_test.go
@@ -3,9 +3,12 @@ package gitcmd
 import (
 	"encoding/hex"
 	"testing"
+
+	"go.science.ru.nl/log"
 )
 
 func TestHash(t *testing.T) {
+	log.Discard()
 	g := New("", "", ".", "", nil)
 
 	hash := g.Hash()

--- a/setup_test.go
+++ b/setup_test.go
@@ -3,9 +3,12 @@ package main
 import (
 	"os"
 	"testing"
+
+	"go.science.ru.nl/log"
 )
 
 func TestInitialGitCheckout(t *testing.T) {
+	log.Discard()
 	temp, err := os.MkdirTemp(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("Failed to make temp dir: %q: %s", temp, err)


### PR DESCRIPTION
Check number of bindmounts done and restart service when > 0. Also clear
logging when running tests, so go test -v looks clean.

Signed-off-by: Miek Gieben <miek@miek.nl>
