### PR TITLE
ospkg: add tooling to install package

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ a GitOps workflow without resorting to Kubernetes like environments.
 The Git repository that you are using to provision the services must have at least one
 (sub)directory for each service.
 
+Gitopper will install packages if told to do so. It will not upgrade or downgrade them, assuming
+there is a better way of doing those.
+
 ## Features Implemented
 
 From the doc:
@@ -164,6 +167,5 @@ TODO...? Some plugins based solution?
 
 ## TODO
 
-* install packages
 * Authentication for destructive action
 * TLS (certmagic?)

--- a/config.go
+++ b/config.go
@@ -30,7 +30,7 @@ func parseConfig(doc []byte) (c Config, err error) {
 // Valid checks the config in c and returns nil of all mandatory fields have been set.
 func (c Config) Valid() error {
 	for i, s := range c.Services {
-		s1 := s.merge(c.Global, 0) // don't care about duration here
+		s1 := s.merge(c.Global)
 		if s1.Machine == "" {
 			return fmt.Errorf("machine #%d, has empty machine name", i)
 		}

--- a/ospkg/archlinux.go
+++ b/ospkg/archlinux.go
@@ -1,0 +1,24 @@
+package ospkg
+
+import (
+	"os/exec"
+)
+
+// ArchLinuxInstaller installs packages on Arch Linux.
+type ArchLinuxInstaller struct{}
+
+var _ Installer = (*ArchLinuxInstaller)(nil)
+
+const pacmanCommand = "/usr/bin/pacman"
+
+func (p *ArchLinuxInstaller) Install(pkg string) error {
+	checkCmd := exec.Command(pacmanCommand, "-Qi", pkg)
+	err := checkCmd.Run()
+	if err == nil {
+		return nil
+	}
+
+	installCmd := exec.Command(pacmanCommand, "-S", "--noconfirm", pkg)
+	_, err = installCmd.CombinedOutput()
+	return err
+}

--- a/ospkg/debian.go
+++ b/ospkg/debian.go
@@ -1,0 +1,27 @@
+package ospkg
+
+import (
+	"os/exec"
+)
+
+// DebianInstaller installs packages on Debian/Ubuntu.
+type DebianInstaller struct{}
+
+var _ Installer = (*DebianInstaller)(nil)
+
+const (
+	aptGetCommand = "/usr/bin/apt-get"
+	dpkgCommand   = "/usr/bin/dpkg"
+)
+
+func (p *DebianInstaller) Install(pkg string) error {
+	checkCmd := exec.Command(dpkgCommand, "-s", pkg)
+	if err := checkCmd.Run(); err == nil {
+		return nil
+	}
+
+	args := []string{"-qq", "--assume-yes", "--no-install-recommends", "install", pkg}
+	installCmd := exec.Command(aptGetCommand, args...)
+	_, err := installCmd.CombinedOutput()
+	return err
+}

--- a/ospkg/installer.go
+++ b/ospkg/installer.go
@@ -4,7 +4,7 @@ import "github.com/miekg/gitopper/osutil"
 
 // Installer represents OS package installation tool.
 type Installer interface {
-	Install(pkg string) error // Install installs the given package at the given version.
+	Install(pkg string) error
 }
 
 // New returns an Installer suited for the current system, or the NoopInstaller when none are found.

--- a/ospkg/installer.go
+++ b/ospkg/installer.go
@@ -1,0 +1,19 @@
+package ospkg
+
+import "github.com/miekg/gitopper/osutil"
+
+// Installer represents OS package installation tool.
+type Installer interface {
+	Install(pkg string) error // Install installs the given package at the given version.
+}
+
+// New returns an Installer suited for the current system, or the NoopInstaller when none are found.
+func New() Installer {
+	switch osutil.ID() {
+	case "debian", "ubuntu":
+		return new(DebianInstaller)
+	case "arch":
+		return new(ArchLinuxInstaller)
+	}
+	return new(NoopInstaller)
+}

--- a/ospkg/noop.go
+++ b/ospkg/noop.go
@@ -1,0 +1,10 @@
+package ospkg
+
+// NoopManager implements a no-op of the Installer interface.
+// Its purpose is to enable scenarios where no package handling is required,
+// i.e. the necessary executables are already available on the host.
+type NoopInstaller struct{}
+
+var _ Installer = (*NoopInstaller)(nil)
+
+func (p *NoopInstaller) Install(pkg string) error { return nil }

--- a/osutil/release.go
+++ b/osutil/release.go
@@ -1,0 +1,31 @@
+package osutil
+
+import (
+	"bytes"
+	"os"
+)
+
+var (
+	// this is a variable so it can be overridden during unit-testing.
+	osRelease = "/etc/os-release"
+)
+
+// ID returns the ID of the system as specific in the osRelease file.
+func ID() string {
+	buf, err := os.ReadFile(osRelease)
+	if err != nil {
+		return ""
+	}
+	i := bytes.Index(buf, []byte("ID="))
+	if i == 0 {
+		return ""
+	}
+	id := buf[i+len("ID="):]
+	j := bytes.Index(id, []byte("\n"))
+	if j == 0 {
+		return ""
+	}
+	// Some attributes are quoted, some are not. Cover both.
+	id = bytes.ReplaceAll(id[:j], []byte("\""), []byte{})
+	return string(id)
+}

--- a/osutil/release_test.go
+++ b/osutil/release_test.go
@@ -1,0 +1,28 @@
+package osutil
+
+import (
+	"testing"
+)
+
+func TestID(t *testing.T) {
+	var tests = []struct {
+		osReleaseFilePath, expected string
+	}{
+		{
+			osReleaseFilePath: "testdata/os-release-rhel77",
+			expected:          "rhel",
+		},
+		{
+			osReleaseFilePath: "testdata/os-release-ubuntu2004",
+			expected:          "ubuntu",
+		},
+	}
+
+	for _, test := range tests {
+		osRelease = test.osReleaseFilePath
+		actual := ID()
+		if test.expected != actual {
+			t.Fatalf("Expected: %q, got :%q", test.expected, actual)
+		}
+	}
+}

--- a/osutil/testdata/os-release-rhel77
+++ b/osutil/testdata/os-release-rhel77
@@ -1,0 +1,17 @@
+NAME="Red Hat Enterprise Linux Server"
+VERSION="7.7 (Maipo)"
+ID="rhel"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="7.7"
+PRETTY_NAME="Red Hat Enterprise Linux Server 7.7 (Maipo)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:7.7:GA:server"
+HOME_URL="https://www.redhat.com/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
+REDHAT_BUGZILLA_PRODUCT_VERSION=7.7
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="7.7"

--- a/osutil/testdata/os-release-ubuntu2004
+++ b/osutil/testdata/os-release-ubuntu2004
@@ -1,0 +1,12 @@
+NAME="Ubuntu"
+VERSION="20.04.1 LTS (Focal Fossa)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 20.04.1 LTS"
+VERSION_ID="20.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=focal
+UBUNTU_CODENAME=focal

--- a/server.go
+++ b/server.go
@@ -15,7 +15,7 @@ import (
 	"go.science.ru.nl/mountinfo"
 )
 
-const Duration = 30 * time.Second // increase when production nears, of make a flag.
+const Duration = 30 * time.Second // increase when production nears, or make a flag.
 
 // Service contains the service configuration tied to a specific machine.
 type Service struct {

--- a/server.go
+++ b/server.go
@@ -15,18 +15,19 @@ import (
 	"go.science.ru.nl/mountinfo"
 )
 
+const Duration = 30 * time.Second // increase when production nears, of make a flag.
+
 // Service contains the service configuration tied to a specific machine.
 type Service struct {
-	Upstream string        // The URL of the (upstream) Git repository.
-	Branch   string        // The branch to track (defaults to 'main').
-	Service  string        // Identifier for the service - will be used for action.
-	Machine  string        // Identifier for this machine - may be shared with multiple machines.
-	Package  string        // The package that might need installing.
-	User     string        // what user to use for checking out the repo.
-	Action   string        // The systemd action to take when files have changed.
-	Mount    string        // Together with Service this is the directory where the sparse git repo is checked out.
-	Dirs     []Dir         // How to map our local directories to the git repository.
-	Duration time.Duration `toml:"_"` // how much to sleep between pulls
+	Upstream string // The URL of the (upstream) Git repository.
+	Branch   string // The branch to track (defaults to 'main').
+	Service  string // Identifier for the service - will be used for action.
+	Machine  string // Identifier for this machine - may be shared with multiple machines.
+	Package  string // The package that might need installing.
+	User     string // what user to use for checking out the repo.
+	Action   string // The systemd action to take when files have changed.
+	Mount    string // Together with Service this is the directory where the sparse git repo is checked out.
+	Dirs     []Dir  // How to map our local directories to the git repository.
 
 	state        State
 	stateInfo    string    // Extra info some states carry.
@@ -99,12 +100,14 @@ func (s *Service) Change() time.Time {
 }
 
 // merge merges anything defined in s1 into s and returns the new Service. Currently this is only
-// done for the Upstream field.
-func (s *Service) merge(s1 *Service, d time.Duration) *Service {
+// done for the Upstream and Branch field.
+func (s *Service) merge(s1 *Service) *Service {
 	if s1.Upstream != "" {
 		s.Upstream = s1.Upstream
 	}
-	s.Duration = d
+	if s1.Branch != "" {
+		s.Branch = s1.Branch
+	}
 	if s.Branch == "" {
 		s.Branch = "main"
 	}
@@ -141,7 +144,7 @@ func (s *Service) trackUpstream(ctx context.Context) {
 		state, info := s.State()
 
 		select {
-		case <-time.After(s.Duration):
+		case <-time.After(Duration):
 		case <-ctx.Done():
 			return
 		}


### PR DESCRIPTION
Copied from systemk, cleaned up and simplified. Install a package when
instructed to do so.

/etc/os-release is used to detect the current OS.

Signed-off-by: Miek Gieben <miek@miek.nl>
