### PR TITLE
server: redo metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -7,9 +7,25 @@ import (
 
 // do we have a latecy that we can track?
 
-var metricServiceHash = promauto.NewGaugeVec(prometheus.GaugeOpts{
-	Namespace: "gitopper",
-	Subsystem: "service",
-	Name:      "info",
-	Help:      "Current hash and state for this service",
-}, []string{"service", "hash", "state"})
+var (
+	metricServiceHash = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "gitopper",
+		Subsystem: "service",
+		Name:      "hash",
+		Help:      "Current hash for this service.",
+	}, []string{"service"})
+
+	metricServiceState = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "gitopper",
+		Subsystem: "service",
+		Name:      "state",
+		Help:      "Current state for  this service.",
+	}, []string{"service"})
+
+	metricServiceTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "gitopper",
+		Subsystem: "service",
+		Name:      "change_timestamp",
+		Help:      "Timestamp for last service change.",
+	}, []string{"service"})
+)

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"sync"
 	"time"
 
@@ -78,7 +79,10 @@ func (s *Service) SetState(st State, info string) {
 	s.state = st
 	s.stateInfo = info
 
-	metricServiceHash.WithLabelValues(s.Service, s.hash, s.state.String()).Set(1)
+	hashNum, _ := strconv.ParseFloat("0x"+s.hash+".p1", 64)
+	metricServiceHash.WithLabelValues(s.Service).Set(hashNum)
+	metricServiceState.WithLabelValues(s.Service).Set(float64(s.state))
+	metricServiceTimestamp.WithLabelValues(s.Service).Set(float64(s.stateStamp.Unix()))
 }
 
 func (s *Service) Hash() string {
@@ -142,6 +146,7 @@ func (s *Service) trackUpstream(ctx context.Context) {
 	for {
 		s.SetHash(gc.Hash())
 		state, info := s.State()
+		s.SetState(state, info)
 
 		select {
 		case <-time.After(Duration):


### PR DESCRIPTION
Current way of doing metrics generates a new one for each state change

gitopper_service_info{state="OK", hash="...", service=".."} gitopper_service_info{state="FREEZE", hash="...", service=".."}

etc. What we want is 1 metric that tells us the state:

gitopper_service_hash{service="..."} <hash>

where hash is the SHA1 converted to a float64

State like wise needs to be encoded as a float as well, so we just use the value we created internally.

gitopper_service_state{service="..."} <state>

where state is 0 1 2 3 4, etc. depending on the number of states.

Then maybe lastly we want a state change timestamp:

gitopper_service_change_timestamp{service=".."} <epoch> when we the last state change.

Signed-off-by: Miek Gieben <miek@science.ru.nl>