### PR TITLE
main, config: Make adding keys easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ upstream = "https://github.com/miekg/blah-origin"  # repository where to downloa
 mount = "/tmp"                                     # directory where to download to, mount+service is used as path
 
 # ssh keys that are allowed in via authorized keys
-[[keys]]
-path = "/home/bla/.ssh/key.pub"
+[keys]
+path = ["/home/bla/.ssh/key.pub"]
 
 # each managed service has an entry like this
 [[services]]

--- a/config.go
+++ b/config.go
@@ -17,13 +17,12 @@ import (
 // Config holds the gitopper config file. It's is updated every so often to pick up new changes.
 type Config struct {
 	Global   *Service
-	Keys     []Key
+	Keys     Key
 	Services []*Service
 }
 
-// Key holds the meta data to find public keys.
 type Key struct {
-	Path string
+	Path []string
 }
 
 func parseConfig(doc []byte) (c Config, err error) {
@@ -35,7 +34,7 @@ func parseConfig(doc []byte) (c Config, err error) {
 
 // Valid checks the config in c and returns nil of all mandatory fields have been set.
 func (c Config) Valid() error {
-	if len(c.Keys) == 0 {
+	if len(c.Keys.Path) == 0 {
 		return fmt.Errorf("at least one public key should be specified")
 	}
 

--- a/config.toml
+++ b/config.toml
@@ -1,19 +1,22 @@
 [global]
 upstream = "https://github.com/miekg/blah-origin"  # repository where to download from
-mount = "/tmp"                                # directory where to download to, mount+service is used as path
+mount = "/tmp"                                     # directory where to download to, mount+service is used as path
 
-[[keys]]
-path = "keys/miek_id_ed25519_gitopper.pub"
+[keys]
+path = [
+	"keys/miek_id_ed25519_gitopper.pub",
+	"/local/home/miek/.ssh/id_ed25519_gitopper.pub",
+]
 
 [[services]]
 machine = "grafana.atoom.net"
 branch = "main"
 service = "grafana-server" # as used in systemd
 user = "grafana"
-package = "grafana"  # as used by package mgmt
-action = "restart"    # what to do when files are changed
-mount = "/tmp/grafana1" # where to download the repo - we don't care
+package = "grafana"     # as used by package mgmt
+action = "restart"      # what to do when files are changed
+mount = "/tmp/grafana1" # override mount here
 dirs = [
-    { local = "/etc/grafana", link = "grafana/etc" },
-    { local = "/var/lib/grafana/dashboards", link = "grafana/dashboards" }
+	{ local = "/etc/grafana", link = "grafana/etc" },
+	{ local = "/var/lib/grafana/dashboards", link = "grafana/dashboards" }
 ]

--- a/main.go
+++ b/main.go
@@ -119,15 +119,15 @@ func run(exec *ExecContext) error {
 		c.Services = append(c.Services, self)
 	}
 
-	allowed := make([]ssh.PublicKey, len(c.Keys))
-	for i, k := range c.Keys {
-		if !path.IsAbs(k.Path) && self != nil { // bootstrapping
-			newpath := path.Join(path.Join(path.Join(self.Mount, self.Service), exec.Dir), k.Path)
-			k.Path = newpath
+	allowed := make([]ssh.PublicKey, len(c.Keys.Path))
+	for i, p := range c.Keys.Path {
+		if !path.IsAbs(p) && self != nil { // bootstrapping
+			newpath := path.Join(path.Join(path.Join(self.Mount, self.Service), exec.Dir), p)
+			p = newpath
 		}
 
-		log.Infof("Reading public key %q", k.Path)
-		data, err := ioutil.ReadFile(k.Path)
+		log.Infof("Reading public key %q", p)
+		data, err := ioutil.ReadFile(p)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -159,7 +159,7 @@ func run(exec *ExecContext) error {
 			log.Fatal(err)
 		}
 	}()
-	log.Infof("Launched servers on port %s and %s from machines: %v", exec.SAddr, exec.MAddr, exec.Hosts)
+	log.Infof("Launched servers on port %s (ssh) and %s (metrics) for machines: %v, %d public keys loaded", exec.SAddr, exec.MAddr, exec.Hosts, len(c.Keys.Path))
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()


### PR DESCRIPTION
Make keys just list a bunch of paths, so we don't need to repeat [[keys]] for every public keyss.

"Launched.... " line in main slightly more informative.

Signed-off-by: Miek Gieben <miek@science.ru.nl>