### PR TITLE
refactor/graceful http shutdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	golang.org/x/crypto v0.3.0
 )
 
+require github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 // indirect
+
 require (
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
+github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
+github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/main_test.go
+++ b/main_test.go
@@ -3,9 +3,13 @@ package main
 import (
 	"errors"
 	"flag"
+	"fmt"
+	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/phayes/freeport"
 )
 
 func TestFlags(t *testing.T) {
@@ -73,4 +77,44 @@ func TestEndToEnd(t *testing.T) {
 	if got, want := err, ErrNotRoot; !errors.Is(got, want) {
 		t.Errorf("run(exec) = %v, want %v", got, want)
 	}
+}
+
+func port(t *testing.T) int {
+	t.Helper()
+	p, err := freeport.GetFreePort()
+	if err != nil {
+		t.Fatalf("acquire port: %v", err)
+	}
+	return p
+}
+
+// httpClient returns a pristine HTTP client that does not use the shared
+// connection cache.  Shared connection caches have produced flaky tests in the
+// past.
+func httpClient() *http.Client {
+	return &http.Client{Transport: new(http.Transport)}
+}
+
+func TestServeMonitoring(t *testing.T) {
+	p := port(t)
+	exec := &ExecContext{
+		MAddr:   fmt.Sprintf(":%v", p),
+		HTTPMux: http.NewServeMux(),
+	}
+	var controllerWG, workerWG sync.WaitGroup
+	workerWG.Add(1)
+	if err := serveMonitoring(exec, &controllerWG, &workerWG); err != nil {
+		t.Fatalf("serveMonitoring(exec, &controllerWG, &workerWG) = %v, want %v", err, error(nil))
+	}
+	client := httpClient()
+	resp, err := client.Get(fmt.Sprintf("http://localhost:%v/metrics", p))
+	if err != nil {
+		t.Fatalf(`client.Get("http://localhost:%v/metrics") err = %v, want %v`, p, err, error(nil))
+	}
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Errorf("after HTTP GET, resp.StatusCode = %v, want %v", got, want)
+	}
+	t.Log("Stopping workers; should unlock controllerWG")
+	workerWG.Done()
+	controllerWG.Wait()
 }

--- a/ssh.go
+++ b/ssh.go
@@ -14,8 +14,8 @@ import (
 	"go.science.ru.nl/log"
 )
 
-func newRouter(c Config, hosts []string) {
-	ssh.Handle(func(s ssh.Session) {
+func newRouter(c Config, hosts []string) ssh.Handler {
+	return func(s ssh.Session) {
 		if len(s.Command()) == 0 {
 			io.WriteString(s, http.StatusText(http.StatusBadRequest))
 			s.Exit(http.StatusBadRequest)
@@ -30,7 +30,7 @@ func newRouter(c Config, hosts []string) {
 
 		io.WriteString(s, http.StatusText(http.StatusNotFound))
 		s.Exit(http.StatusNotFound)
-	})
+	}
 }
 
 var routes = map[string]func(Config, ssh.Session, []string){


### PR DESCRIPTION
This commit extracts HTTP and SSH interface setup and running from the
runner routine, because the code becomes unwieldy when graceful
draining is bolted on.  Meanwhile tests are added for the HTTP
interface.