### PR TITLE
Fix installing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ From the [doc](https://miek.nl/2022/november/15/provisioning-services/):
 And things should work then. I.e. in /etc/prometheus you should see the content of the
 *miekg/gitopper-config* repository.
 
-The checked out git repo in /tmp/prometheus should _only_ contain the prometheus directory
-thanks to the sparse checkout. Changes made to the `crap` subdir in that repo do not trigger a
-prometheus reload.
+The checked out git repo in /tmp/prometheus should _only_ contain the prometheus directory thanks to
+the sparse checkout. Changes made to any other subdirectory in that repo do not trigger a prometheus
+reload.
 
 Then with cmd/gitopperctl/gitopperctl you can query the server:
 

--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,6 @@ mount = "/tmp"
 [keys]
 path = [
 	"keys/miek_id_ed25519_gitopper.pub",
-	"/local/home/miek/.ssh/id_ed25519_gitopper.pub",
 ]
 
 [[services]]

--- a/ospkg/archlinux.go
+++ b/ospkg/archlinux.go
@@ -2,6 +2,8 @@ package ospkg
 
 import (
 	"os/exec"
+
+	"go.science.ru.nl/log"
 )
 
 // ArchLinuxInstaller installs packages on Arch Linux.
@@ -12,13 +14,12 @@ var _ Installer = (*ArchLinuxInstaller)(nil)
 const pacmanCommand = "/usr/bin/pacman"
 
 func (p *ArchLinuxInstaller) Install(pkg string) error {
-	checkCmd := exec.Command(pacmanCommand, "-Qi", pkg)
-	err := checkCmd.Run()
-	if err == nil {
-		return nil
-	}
-
 	installCmd := exec.Command(pacmanCommand, "-S", "--noconfirm", pkg)
-	_, err = installCmd.CombinedOutput()
+	out, err := installCmd.CombinedOutput()
+	if err != nil {
+		log.Warningf("Install failed: %s", out)
+	} else {
+		log.Infof("Already installed or re-installed %q", pkg)
+	}
 	return err
 }

--- a/ospkg/debian.go
+++ b/ospkg/debian.go
@@ -2,6 +2,8 @@ package ospkg
 
 import (
 	"os/exec"
+
+	"go.science.ru.nl/log"
 )
 
 // DebianInstaller installs packages on Debian/Ubuntu.
@@ -9,19 +11,16 @@ type DebianInstaller struct{}
 
 var _ Installer = (*DebianInstaller)(nil)
 
-const (
-	aptGetCommand = "/usr/bin/apt-get"
-	dpkgCommand   = "/usr/bin/dpkg"
-)
+const aptGetCommand = "/usr/bin/apt-get"
 
 func (p *DebianInstaller) Install(pkg string) error {
-	checkCmd := exec.Command(dpkgCommand, "-s", pkg)
-	if err := checkCmd.Run(); err == nil {
-		return nil
-	}
-
 	args := []string{"-qq", "--assume-yes", "--no-install-recommends", "install", pkg}
 	installCmd := exec.Command(aptGetCommand, args...)
-	_, err := installCmd.CombinedOutput()
+	out, err := installCmd.CombinedOutput()
+	if err != nil {
+		log.Warningf("Install failed: %s", out)
+	} else {
+		log.Infof("Already installed or re-installed %q", pkg)
+	}
 	return err
 }

--- a/ospkg/installer.go
+++ b/ospkg/installer.go
@@ -1,6 +1,9 @@
 package ospkg
 
-import "github.com/miekg/gitopper/osutil"
+import (
+	"github.com/miekg/gitopper/osutil"
+	"go.science.ru.nl/log"
+)
 
 // Installer represents OS package installation tool.
 type Installer interface {
@@ -15,5 +18,6 @@ func New() Installer {
 	case "arch":
 		return new(ArchLinuxInstaller)
 	}
+	log.Warningf("Returning Noop package installer for %s", osutil.ID())
 	return new(NoopInstaller)
 }

--- a/osutil/release.go
+++ b/osutil/release.go
@@ -16,11 +16,11 @@ func ID() string {
 	if err != nil {
 		return ""
 	}
-	i := bytes.Index(buf, []byte("ID="))
+	i := bytes.Index(buf, []byte("\nID=")) // want ^ID=
 	if i == 0 {
 		return ""
 	}
-	id := buf[i+len("ID="):]
+	id := buf[i+len("\nID="):]
 	j := bytes.Index(id, []byte("\n"))
 	if j == 0 {
 		return ""

--- a/server.go
+++ b/server.go
@@ -271,7 +271,7 @@ func (s *Service) bindmount() (int, error) {
 		}
 
 		ctx := context.TODO()
-		cmd := exec.CommandContext(ctx, "mount", "-r", "--bind", gitdir, d.Local)
+		cmd := exec.CommandContext(ctx, "mount", "--bind", gitdir, d.Local) // mount needs to be r/w for pkg upgrades
 		log.Infof("running %v", cmd.Args)
 		err := cmd.Run()
 		if err != nil {


### PR DESCRIPTION
Fix ospkg.ID() to grab the ID= line and not some random ID= string in
the file. Do a pkg install regardless, should be idempotent once
installed anyway - more logging there too.

Make the bind mounts RW (instead of RO), as with RO pkg reinstall (or
upgrade!) would fail, this does introduce files in the git repo that
may, or may not, create problems.

Signed-off-by: Miek Gieben <miek@miek.nl>
