### PR TITLE
SSH: allow RO keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ becomes BROKEN.
 [global]
 upstream = "https://github.com/miekg/gitopper-config"  # repository where to download from
 mount = "/tmp"                                     # directory where to download to, mount+service is used as path
-
 # ssh keys that are allowed in via authorized keys
-[keys]
-path = ["/home/bla/.ssh/key.pub"]
+keys =[
+	{ path = "keys/miek_id_ed25519_gitopper.pub" },
+	{ path = "keys/another_key.pub", ro = true },
+]
 
 # each managed service has an entry like this
 [[services]]
@@ -187,5 +188,4 @@ Authentication uses SSH, so it fits in with the rest of the infrastructure.
 
 ## TODO
 
-- allow env vars in config
-- Include systemd service file.
+Maybe log public keys paths so we know exactly what keys is meant. Or just comment the toml file?

--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,9 @@
 [global]
 upstream = "https://github.com/miekg/gitopper-config"
 mount = "/tmp"
-
-[keys]
-path = [
-	"keys/miek_id_ed25519_gitopper.pub",
+keys = [
+	{ path = "keys/miek_id_ed25519_gitopper.pub", ro = true },
+	{ path = "/local/home/miek/.ssh/id_ed25519_gitopper.pub"},
 ]
 
 [[services]]

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func serveSSH(exec *ExecContext, controllerWG, workerWG *sync.WaitGroup, allowed
 				return true
 			}
 		}
-		log.Info("No valid keys found for user %q", ctx.User())
+		log.Warningf("No valid keys found for user %q", ctx.User())
 		return false
 	}))
 	controllerWG.Add(1) // Ensure SSH server draining blocks application shutdown.

--- a/server.go
+++ b/server.go
@@ -104,7 +104,7 @@ func (s *Service) Change() time.Time {
 }
 
 // merge merges anything defined in global into s when s doesn't specify it and returns the new Service.
-func (s *Service) merge(global *Service) *Service {
+func (s *Service) merge(global Global) *Service {
 	if s.Upstream == "" {
 		s.Upstream = global.Upstream
 	}

--- a/ssh.go
+++ b/ssh.go
@@ -38,7 +38,7 @@ func newRouter(c Config, hosts []string) ssh.Handler {
 		for prefix, f := range routes {
 			if strings.HasPrefix(s.Command()[0], prefix) {
 				if ro && strings.HasPrefix(s.Command()[0], "/state/") {
-					log.Infof("Key for user %q is set RO and route is RW, denying", s.User())
+					log.Warningf("Key for user %q is set RO and route is RW, denying", s.User())
 					io.WriteString(s, http.StatusText(http.StatusUnauthorized))
 					s.Exit(http.StatusUnauthorized)
 					return


### PR DESCRIPTION
Make keys ro by annotating them in the config.toml file and check if the operation performed is an RO one (currently only list).

This helps for writing a prober that exports the diff status from looking at this output and knowing the latest git commit. This probably means *we* don't have to export the git hash, but only list it from the API.

Probably warrants a small other cmd/ that actually does these checks and sets the 'diff detected' metrics that will then picked up.

Signed-off-by: Miek Gieben <miek@science.ru.nl>