### PR TITLE
add list/config

### DIFF
--- a/cmd/gitopperctl/README.md
+++ b/cmd/gitopperctl/README.md
@@ -18,8 +18,9 @@ from the server.
 In order:
 
 1. List all machines defined in the config file for gitopper running on `<host>`.
-2. List all services that are controlled on `<host>`.
-3. List a specific service on `<host>`.
+1. List all services that are controlled on `<host>`.
+1. List the configuration which service is controlled by what git repo on `<host>`.
+1. List a specific service on `<host>`.
 
 Each will output a simple table with the information:
 

--- a/cmd/gitopperctl/main.go
+++ b/cmd/gitopperctl/main.go
@@ -106,6 +106,41 @@ func main() {
 							return nil
 						},
 					},
+					{
+						Name:    "config",
+						Aliases: []string{"c"},
+						Usage:   "list config @machine",
+						Action: func(ctx *cli.Context) error {
+							at, err := atMachine(ctx)
+							if err != nil {
+								return err
+							}
+							body, err := querySSH(ctx, at, "/list/config")
+							if err != nil {
+								return err
+							}
+							lc := proto.ListConfigs{}
+							if err := json.Unmarshal(body, &lc); err != nil {
+								return err
+							}
+							if ctx.Bool("m") {
+								fmt.Print(string(body))
+								return nil
+							}
+							tbl := table.New("SERVICE", "SYSTEMD", "UPSTREAM", "DIR", "LOCAL")
+							for _, lc := range lc.ListConfigs {
+								for i := range lc.Dirs {
+									if i == 0 {
+										tbl.AddRow(lc.Service, lc.Systemd, lc.Upstream, lc.Dirs[i], lc.Locals[i])
+										continue
+									}
+									tbl.AddRow("", "", "", lc.Dirs[i], lc.Locals[i])
+								}
+							}
+							tbl.Print()
+							return nil
+						},
+					},
 				},
 			},
 			{

--- a/cmd/gitopperctl/main.go
+++ b/cmd/gitopperctl/main.go
@@ -128,6 +128,8 @@ func main() {
 								return nil
 							}
 							tbl := table.New("SERVICE", "SYSTEMD", "UPSTREAM", "DIR", "LOCAL")
+							// we also do this in gitopper, keep this in sync with
+							// ../../main.go
 							for _, lc := range lc.ListConfigs {
 								for i := range lc.Dirs {
 									if i == 0 {

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,6 @@ branch = "main"
 mount = "/tmp/gitopper"
 keys = [
 	{ path = "keys/miek_id_ed25519_gitopper.pub", ro = true },
-	{ path = "/local/home/miek/.ssh/id_ed25519_gitopper.pub"},
 ]
 
 [[services]]
@@ -15,15 +14,4 @@ package = "prometheus"
 action = "reload"
 dirs = [
 	{ local = "/etc/prometheus", link = "prometheus/etc" },
-]
-
-# docker compose needs to work with systemd template files
-[[services]]
-machine = "docker-test"
-service = "docker-compose@caddy"
-user = "docker"
-#package = "docker-compose"
-action = "reload"
-dirs = [
-	{ local = "/tmp/docker-compose.yml", link = "docker-compose/caddy/docker-compose.yml", file = true },
 ]

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -22,4 +22,16 @@ type (
 		StateInfo   string `json:"stateinfo"`
 		StateChange string `json:"change"`
 	}
+
+	ListConfigs struct {
+		ListConfigs []ListConfig `json:"config"`
+	}
+
+	ListConfig struct {
+		Service  string   `json:"service"`
+		Upstream string   `json:"upstream"`
+		Systemd  string   `json:"systemd"`
+		Dirs     []string `json:"dir"`
+		Locals   []string `json:"local"`
+	}
 )

--- a/ssh.go
+++ b/ssh.go
@@ -135,6 +135,12 @@ func ListService(c Config, s ssh.Session, hosts []string) {
 }
 
 func ListConfig(c Config, s ssh.Session, hosts []string) {
+	lc := listConfigs(c, hosts)
+	data, err := json.Marshal(lc)
+	writeAndExit(s, data, err)
+}
+
+func listConfigs(c Config, hosts []string) proto.ListConfigs {
 	lc := proto.ListConfigs{ListConfigs: []proto.ListConfig{}}
 
 	for _, service := range c.Services {
@@ -160,8 +166,7 @@ func ListConfig(c Config, s ssh.Session, hosts []string) {
 
 		lc.ListConfigs = append(lc.ListConfigs, conf)
 	}
-	data, err := json.Marshal(lc)
-	writeAndExit(s, data, err)
+	return lc
 }
 
 func FreezeService(c Config, s ssh.Session, hosts []string) {


### PR DESCRIPTION
This list the gitoppoer config, so you can put it in motd, and lists the
services that are managed by gitopper, so there is some indication that
you should't edit any config files there. Output looks like:

~~~
% ./gitopperctl -i ~/.ssh/id_ed25519_gitopper list config @localhost
SERVICE     SYSTEMD  UPSTREAM                                  DIR             LOCAL
prometheus  reload   https://github.com/miekg/gitopper-config  prometheus/etc  /etc/prometheus
~~~

i.e. you can prefix this, with: This system is (partly) managed by
gitopper: etc..

Might be worth thing about having such hints in the config files
themselves as well.

Signed-off-by: Miek Gieben <miek@miek.nl>
