### PR TITLE
add DIFF state

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,12 @@ would be nice to have this state in the git repo somehow?).
 * `FREEZE`: everything is running, but we're not tracking upstream.
 * `ROLLBACK`: everything is running, but we're not tracking upstream *and* we're pinned to an older
   commit. This state is quickly followed by FREEZE if we were successful rolling back, otherwise
-  BROKEN.
+  BROKEN (systemd error)  of DIFF (git error)
 * `BROKEN`: something with the service is broken, we're still tracking upstream.
+* `DIFF`: the git repository can't be reconciled with upstream.
 
 ROLLBACK is a transient state and quickly moves to FREEZE, unless something goes wrong then it
-becomes BROKEN.
-
-If ROLLBACK stays in ROLLBACK for a longer period it means the commit it needs to rollback to can't
-be found.
+becomes BROKEN, or DIFF depending on what goes wrong (systemd, or git respectively).
 
 ## Config File
 
@@ -154,9 +152,8 @@ table.
 
 The following metrics are exported:
 
-* gitopper_service_hash{"service"} \<hash\>
 * gitopper_service_state{"service"} \<state\>
-* gitopper_service_change_timestamp{"service"} \<epoch\>
+* gitopper_service_change_times_seconds{"service"} \<epoch\>
 * gitopper_machine_git_errors_total - total number of errors when running git.
 * gitopper_machine_git_ops_total - total number of git runs.
 
@@ -172,7 +169,7 @@ Gitopper has following exit codes:
 ## Bootstrapping
 
 There are a couple of options that allow gitopper to bootstrap itself *and* make gitopper to be
-managed by gitopper. Basically those options allow you to specificy a service on the command line.
+managed by gitopper. Basically those options allow you to specify a service on the command line.
 Gitopper will check out the repo and then proceed to read the config *in that repo* and setup
 everything from there.
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ would be nice to have this state in the git repo somehow?).
 * `ROLLBACK`: everything is running, but we're not tracking upstream *and* we're pinned to an older
   commit. This state is quickly followed by FREEZE if we were successful rolling back, otherwise
   BROKEN (systemd error)  of DIFF (git error)
-* `BROKEN`: something with the service is broken, we're still tracking upstream.
-* `DIFF`: the git repository can't be reconciled with upstream.
+* `BROKEN`: something with the service is broken, we're still tracking upstream. I.e. systemd error.
+* `DIFF`: the git repository can't be reconciled with upstream. I.e. git error.
 
 ROLLBACK is a transient state and quickly moves to FREEZE, unless something goes wrong then it
 becomes BROKEN, or DIFF depending on what goes wrong (systemd, or git respectively).

--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ would be nice to have this state in the git repo somehow?).
 ROLLBACK is a transient state and quickly moves to FREEZE, unless something goes wrong then it
 becomes BROKEN, or DIFF depending on what goes wrong (systemd, or git respectively).
 
+~~~
+ +-------------------------+
+ |                         |
+ v                         |
+*OK -------> ROLLBACK ---> FREEZE
+ |          /    \         |
+ |         /      \        v
+ |        |        |       |
+ |        v        v       |
+ |      BROKEN     DIFF    |
+ |        |         |      |
+ |        |         |      |
+ +--------+---------+------+
+~~~
+
+- `*OK` is the start state
+- from `OK` and `FREEZE` we can still end up in `BROKEN` and `FREEZE` and vice versa.
+
 ## Config File
 
 ~~~ toml

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ table.
 The following metrics are exported:
 
 * gitopper_service_state{"service"} \<state\>
-* gitopper_service_change_times_seconds{"service"} \<epoch\>
+* gitopper_service_change_time_seconds{"service"} \<epoch\>
 * gitopper_machine_git_errors_total - total number of errors when running git.
 * gitopper_machine_git_ops_total - total number of git runs.
 

--- a/main.go
+++ b/main.go
@@ -271,7 +271,7 @@ func run(exec *ExecContext) error {
 		err := gc.Checkout()
 		if err != nil {
 			log.Warningf("Service %q, error pulling repo %q: %s", s.Service, s.Upstream, err)
-			s.SetState(StateBroken, fmt.Sprintf("error pulling %q: %s", s.Upstream, err))
+			s.SetState(StateDiff, fmt.Sprintf("error pulling %q: %s", s.Upstream, err))
 			continue
 		}
 

--- a/metrics.go
+++ b/metrics.go
@@ -8,24 +8,17 @@ import (
 // do we have a latecy that we can track?
 
 var (
-	metricServiceHash = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "gitopper",
-		Subsystem: "service",
-		Name:      "hash",
-		Help:      "Current hash for this service.",
-	}, []string{"service"})
-
 	metricServiceState = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "gitopper",
 		Subsystem: "service",
 		Name:      "state",
-		Help:      "Current state for  this service.",
+		Help:      "Current state for this service.",
 	}, []string{"service"})
 
 	metricServiceTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "gitopper",
 		Subsystem: "service",
-		Name:      "change_timestamp",
-		Help:      "Timestamp for last service change.",
+		Name:      "change_time_seconds",
+		Help:      "Timestamp for last state change for this service.",
 	}, []string{"service"})
 )


### PR DESCRIPTION
Don't export the git hashes, but if a git pull fails, set the state to
DIFF.

Signed-off-by: Miek Gieben <miek@miek.nl>
