### PR TITLE
Bug with long pathnames

### DIFF
--- a/gitcmd/diffstat.go
+++ b/gitcmd/diffstat.go
@@ -28,11 +28,9 @@ func (g *Git) OfInterest(data []byte) bool {
 	// bunch of lines usually < 1000. So it's not too bad.
 	for scanner.Scan() {
 		text := scanner.Text()
-		if strings.HasPrefix(text, " ") && strings.Contains(text, " | ") {
-			for _, d := range g.dirs {
-				if strings.Contains(text, d) {
-					return true
-				}
+		for _, d := range g.dirs {
+			if strings.Contains(text, d) {
+				return true
 			}
 		}
 	}

--- a/gitcmd/git.go
+++ b/gitcmd/git.go
@@ -120,8 +120,14 @@ func (g *Git) Pull() (bool, error) {
 	g.cwd = g.mount
 	defer func() { g.cwd = "" }()
 
-	out, err := g.run("pull", "--stat", "origin", g.branch)
+	if _, err := g.run("fetch"); err != nil {
+		return false, err
+	}
+	out, err := g.run("diff", "--stat=4096", "--name-only", g.branch, fmt.Sprintf("origin/%s", g.branch))
 	if err != nil {
+		return false, err
+	}
+	if _, err := g.run("merge"); err != nil {
 		return false, err
 	}
 	return g.OfInterest(out), nil


### PR DESCRIPTION
There is a bug with paths longer than 80 characters. When running `git pull --stat` for changes with these long paths. You get a truncated path:

```
.../deeply/nested/directory/hierarchy/this.service | 6 +++---
```

This will not match the set `dir` in the gitopper configuration.

Unfortunately you cannot set the maximum width in `git pull --stat` but possible with `git diff --stat`. We have to separate the steps when checking for changes. That is, `git fetch`, `git diff`, then `git merge`. The default kernel-imposed limit in Linux is 4096 so just use that too.

It does `git diff` now so we can also set `--name-only` to get a clean output for string matching. We can skip matching the path inside the `git pull --stat` output format.