### PR TITLE
Bootstrap should call systemctl start on the unit.

### DIFF
--- a/main.go
+++ b/main.go
@@ -290,9 +290,9 @@ func run(exec *ExecContext) error {
 			if rerr := s.reload(); rerr != nil {
 				log.Warningf("Service %q, error running systemctl daemon-reload: %s", s.Service, rerr)
 				s.SetState(StateBroken, fmt.Sprintf("error running systemctl daemon-reload %q: %s", s.Upstream, rerr))
-			} else if err := s.systemctl(); err != nil {
-				log.Warningf("Service %q, error running systemctl: %s", s.Service, err)
-				s.SetState(StateBroken, fmt.Sprintf("error running systemctl %q: %s", s.Upstream, err))
+			} else if err := s.start(); err != nil {
+				log.Warningf("Service %q, error running systemctl start: %s", s.Service, err)
+				s.SetState(StateBroken, fmt.Sprintf("error running systemctl start %q: %s", s.Upstream, err))
 				// no continue; maybe git pull will make this work later
 			} else {
 				s.SetState(StateOK, "")

--- a/server.go
+++ b/server.go
@@ -259,6 +259,13 @@ func (s *Service) enable() error {
 	return cmd.Run()
 }
 
+func (s *Service) start() error {
+	ctx := context.TODO()
+	cmd := exec.CommandContext(ctx, "systemctl", "start", s.Service)
+	log.Infof("running %v", cmd.Args)
+	return cmd.Run()
+}
+
 // Boot returns the start time of the service. If that isn't available because there isn't a Service in s, then we
 // return the kernel's boot time (i.e. when the system we started).
 func (s *Service) SetBoot() {


### PR DESCRIPTION
The `Action` set might be `reload` and that would not start the unit.

Should call `systemctl start` during bootstrap.